### PR TITLE
Remove text-align:center from h1

### DIFF
--- a/static/styles/main.scss
+++ b/static/styles/main.scss
@@ -104,7 +104,6 @@ h1 {
 
     font-size: em(56);
     line-height: 1em;
-    text-align: center;
     margin-top: 0;
     margin-bottom: em(24, 56);
     color: white;


### PR DESCRIPTION
Misaligned headers make the baby jeebus sad.
